### PR TITLE
update package.json with npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Official HabitRPG mobile app, build with [PhoneGap](http://cordova.apache.org/) 
 ##Install the mobile app
  * [Install Node](http://nodejs.org/)
  * `npm install -g yo generator-angular grunt-cli bower`
- * `npm install && bower install`
- * `grunt server`
+ * `npm install`
+ * `npm start`
  * Run the Ripple Emulator in your browser open browser at http://localhost:9000
    * Turn off tooltips
    * Disable cross domain proxy

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "yo",
-  "version": "0.0.0",
+  "name": "habitrpg-mobile",
+  "version": "0.0.1",
   "dependencies": {},
   "devDependencies": {
     "grunt": "~0.4.1",
@@ -27,10 +27,18 @@
     "grunt-google-cdn": "~0.2.0",
     "grunt-ngmin": "~0.0.2"
   },
+  "peerDependencies": {
+    "grunt-cli": "*",
+    "yo": "*",
+    "generator-angular": "*",
+    "bower": "*"
+  },
   "engines": {
     "node": ">=0.8.0"
   },
   "scripts": {
+    "start": "grunt server",
+    "postinstall": "bower install",
     "test": "grunt test"
   }
 }


### PR DESCRIPTION
- Add peerDependencies for yo, generator-angular, grunt-cli, and bower. npm will complain if you try installing this package and not have those installed.
- `npm start` will run `grunt server` to make it conform better to all `npm start`s
- do `bower install` in npm's `postinstall` script so we don't have to worry about it.
