### PR TITLE
Fix notifications not showing in details pages

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -95,6 +95,9 @@
                     </div>
 
                     <!-- Main View -->
+                    <div ng-controller="NotificationCtrl">
+                        <div id="notification"><div ng-bind-html-unsafe="data.message"></div></div>
+                    </div>
                     <div ng-view ng-cloak></div>
                 </div>
             </div>

--- a/app/views/list.html
+++ b/app/views/list.html
@@ -1,7 +1,3 @@
-<div ng-controller="NotificationCtrl">
-<div id="notification"><div ng-bind-html-unsafe="data.message"></div></div>
-</div>
-
 <!-- Don't show tasks if dead -->
 <div ng-show="user.stats.hp <= 0">
     <h1>You are dead</h1>


### PR DESCRIPTION
Notifications aren't showing in details page and in every page except the ones which uses the `list.html` template.

This is a simple fix moving the necessary html to `index.html`.
