### PR TITLE
Show pet in profile page

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -859,6 +859,19 @@ ul.stats-list {
   -webkit-overflow-scroll: touch;
 }
 
+.profile-content .herobox .hasPet{
+  margin-left: 20px;
+}
+
+.profile-content .herobox .current-pet{
+  display: none;
+}
+
+.profile-content .herobox .hasPet .current-pet{
+  display: block;
+  margin-top: 24px;
+  margin-left: -25px;
+}
 
 .taskTypeHeader {
   color: rgb(51,51,51);

--- a/app/views/profile.html
+++ b/app/views/profile.html
@@ -11,7 +11,7 @@
         <div ng-hide="customize">
 
             <div class="herobox">
-                <div class='character-sprites' ng-click="showUserAvatar()">
+                <div class='character-sprites' ng-class='{hasPet: user.items.currentPet}' ng-click="showUserAvatar()">
                     <span class='zzz' ng-show='user.flags.rest'></span>
                     <span class='{{user.preferences.gender}}_skin_{{user.preferences.skin}}'></span>
                     <span class='{{user.preferences.gender}}_hair_{{user.preferences.hair}}'></span>
@@ -20,6 +20,8 @@
                     <span class="{{equipped(user, 'head')}}"></span>
                     <span class='{{user.preferences.gender}}_shield_{{user.items.shield}}'></span>
                     <span class='{{user.preferences.gender}}_weapon_{{user.items.weapon}}'></span>
+                    <!-- current-pet class is used also on the website, in case it's moved from the website to habitrpg-shared, change it to another name here because they use different css !-->
+                    <span class='Pet-{{user.items.currentPet.str}} current-pet'></span>
                 </div>
             </div>
 


### PR DESCRIPTION
This pull request shows the user's pet in the profile page if the user has one.

![schermata del 2013-08-31 12 21 17](https://f.cloud.github.com/assets/589911/1062114/6adbca30-1227-11e3-9eed-92c1158422ba.png)

The only problem is when the resolution with is less then 320, here is how it appears on a 240x320:

![schermata del 2013-08-31 12 22 11](https://f.cloud.github.com/assets/589911/1062116/877da776-1227-11e3-8c2f-6c7e319565c8.png)

But also the avatar is not shown correctly:

![schermata del 2013-08-31 12 22 22](https://f.cloud.github.com/assets/589911/1062117/9a5a1b18-1227-11e3-856e-396173d5cc60.png)

And I don't think anyone is using a 240x320 resolutions and in any case it's not preventing any functionality.

I tried to set the pet position as on the website as much as possible.
