### PR TITLE
Back button hide

### DIFF
--- a/scripts/controllers/rootCtrl.js
+++ b/scripts/controllers/rootCtrl.js
@@ -2,8 +2,8 @@
 
 // Make user and settings available for everyone through root scope.
 habitrpg.controller('RootCtrl',
-  ['$scope', '$rootScope', '$location', 'User', '$state', '$stateParams', '$window', '$ionicPlatform', 'Groups',
-  function ($scope, $rootScope, $location, User, $state, $stateParams, $window, $ionicPlatform, Groups) {
+  ['$scope', '$rootScope', '$location', '$ionicNavBarDelegate', 'User', '$state', '$stateParams', '$window', '$ionicPlatform', 'Groups',
+  function ($scope, $rootScope, $location, $ionicNavBarDelegate, User, $state, $stateParams, $window, $ionicPlatform, Groups) {
 
     $rootScope.User = User;
     $rootScope.user = User.user;
@@ -49,6 +49,10 @@ habitrpg.controller('RootCtrl',
 
     $rootScope.goBack = function() {
       history.back();
+    }
+
+    $rootScope.getPreviousTitle = function() {
+      return $ionicNavBarDelegate.getPreviousTitle();
     }
 
     $scope.hideBackButton = function() {

--- a/views/app.jade
+++ b/views/app.jade
@@ -17,7 +17,7 @@ script(id='views/app.html',type='text/ng-template')
       ion-nav-bar.bar-stable(align-title='left')
         .button.button-clear(ng-hide='hideBackButton()' ng-click='goBack()')
           i.icon.ion-chevron-left
-          | Back
+          | {{getPreviousTitle() || 'Back'}}
 
       ion-nav-view(name='menuContent', animation='slide-left-right')
     ion-side-menu(side='left')


### PR DESCRIPTION
The back buttons remain visible when you go back from viewing habits, todos, etc. This will hide the back button for all the base routes like `/app/tasks/dailies/` `app/profile/avatar`.
It's not elegant as it uses regex, so if you guys don't like it we can come up with a better solution.
