### PR TITLE
gulp-clean is deprecated and superseded by gulp-rimraf

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,7 @@ var rename = require('gulp-rename');
 var connect = require('gulp-connect');
 var stylus = require('gulp-stylus');
 var uglify = require('gulp-uglify');
-var clean = require('gulp-clean');
+var rimraf = require('gulp-rimraf');
 var i18n = require('habitrpg/src/i18n');
 var _ = require('habitrpg/node_modules/lodash');
 var shared = require('habitrpg/node_modules/habitrpg-shared');
@@ -70,7 +70,7 @@ var dist = './www';
 
 gulp.task('clean', function(){
   return gulp.src('./www/bower_components/', {read: false})
-    .pipe(clean())
+    .pipe(rimraf())
 })
 
 gulp.task('copy', ['clean'], function(){

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "gulp-stylus": "~1.0.0",
     "habitrpg": "HabitRPG/habitrpg#develop",
     "gulp-uglify": "~0.2.1",
-    "gulp-clean": "~0.2.4",
+    "gulp-rimraf": "~0.1.0",
     "cordova-gen-icon": "https://bitbucket.org/lefnire/cordova-gen-icon/get/lefnire/cordovageniconjs-edited-online-with-bitb-1398874449722.tar.gz"
   },
   "scripts": {


### PR DESCRIPTION
This replaces gulp-clean with gulp-rimraf, as gulp-clean is deprecated.

See: https://www.npmjs.org/package/gulp-clean
