### PR TITLE
add details to rewards

### DIFF
--- a/styles/app.styl
+++ b/styles/app.styl
@@ -77,7 +77,7 @@ for $stage in (worst $worst) (worse $worse) (bad $bad) (neutral $neutral) (good 
 .pull-left {float:left;}
 .pull-right {float:right;}
 .shop-sprites
-  margin: 4px;
+  margin: 4px 20px 4px 4px;
   td {vertical-align: middle;}
 
 .exp-and-gold
@@ -100,13 +100,13 @@ for $stage in (worst $worst) (worse $worse) (bad $bad) (neutral $neutral) (good 
 
   &.locked
     background-color: #727272
-  
+
 .meter
   width: 100%
   height: 25px
-  // color taken from default ionic coulours, 
+  // color taken from default ionic coulours,
   // applying class balanced-color doesn't work
-  border: 1px solid #498f24 
+  border: 1px solid #498f24
 
   &> span
     display: inline-block

--- a/views/app/list.jade
+++ b/views/app/list.jade
@@ -64,7 +64,8 @@ mixin taskList(k)
                   td
                     .shop-sprite.item-img(class="shop_{{::item.key}}")
                   td
-                    span(ng-click='selectTask(item)') {{::item.text()}}
+                    span {{::item.text()}}
+                    div.item-note {{::item.notes()}}
 
 script(id='views/app.tasks.html',type='text/ng-template')
   //-+ionContentView(nav.name, [{class:'ion-plus-round',fn:"addTask(_newTask,'"+k+"')"}])


### PR DESCRIPTION
I think it's helpful to be able to see the what the items you're buying actually do in terms of stats. 
I was going to add it to a detailed view but it seems unnecessary since you can't edit them or anything.
How about like this?

![item_notes](https://cloud.githubusercontent.com/assets/6372245/3744842/1b47470e-179b-11e4-8bd0-567417352d65.png)

note: `selectTask(item)` doesn't seem to do anything so I removed it.
