### PR TITLE
don't ignore emoji images

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,7 +61,7 @@ var paths = {
     'bower_components/**/*',
     '!bower_components/habitrpg-shared/node_modules/**/*',
     '!bower_components/habitrpg-shared/img/unprocessed/**/*',
-    '!bower_components/habitrpg-shared/img/emoji/**/*',
+    //'!bower_components/habitrpg-shared/img/emoji/**/*',
     '!bower_components/habitrpg-shared/img/project_files/**/*',
     '!bower_components/habitrpg-shared/.git/**/*', // I'm using symlink
     '!bower_components/angular/**/*',


### PR DESCRIPTION
See #162

This will comment out the "ignore emoji images" line out.

It is strange that it has worked on previous versions.
