### PR TITLE
Add small-mode setting

### DIFF
--- a/styles/app.styl
+++ b/styles/app.styl
@@ -55,6 +55,22 @@ for $stage in (worst $worst) (worse $worse) (bad $bad) (neutral $neutral) (good 
   p {color: #999;}
 .task-reward > .item-content {background-color: white !important;}
 
+/* Small Mode */
+ion-item.small-mode > .item-content {
+  padding-top: 10px !important;
+  padding-bottom: 10px !important;
+}
+
+.item-button-left > button > .small-mode.checkbox-icon {
+  margin-top: -10px;
+}
+
+.item-button-right > .buttons > .small-mode.button {
+  height: 25px;
+  margin-top: -10px;
+  padding-top: 0;
+}
+
 .avatar-box
   padding 0
   vertical-align top

--- a/views/app/list.jade
+++ b/views/app/list.jade
@@ -30,17 +30,17 @@ mixin taskList(k)
           if k=='reward'
             .item.item-divider Custom Rewards
 
-          ion-item.item-text-wrap(class='task-#{k}', on-hold="actionSheet(task)", ng-click="viewTask(task)", ng-repeat='task in user.#{k}s | filter:taskFilter',ng-class=' ::[getClass(task.value),(task.completed || notDue(task)) ? "completed" : ""]')
+          ion-item.item-text-wrap(class='task-#{k}', on-hold="actionSheet(task)", ng-click="viewTask(task)", ng-repeat='task in user.#{k}s | filter:taskFilter',ng-class=' ::[getClass(task.value),(task.completed || notDue(task)) ? "completed" : "", settings.smallMode ? "small-mode" : ""]')
             if k=='habit'
               .item-button-right
                 .buttons
-                  button.button.button-small.icon.ion-plus-round(ng-click='score(task,"up", $event);changeColor(task, $event)', ng-show=' ::task.up')
-                  button.button.button-small.icon.ion-minus-round(ng-click='score(task,"down", $event); changeColor(task, $event)', ng-show=' ::task.down')
+                  button.button.button-small.icon.ion-plus-round(ng-click='score(task,"up", $event);changeColor(task, $event)', ng-show=' ::task.up', ng-class=" ::{'small-mode': settings.smallMode}")
+                  button.button.button-small.icon.ion-minus-round(ng-click='score(task,"down", $event); changeColor(task, $event)', ng-show=' ::task.down', ng-class=" ::{'small-mode': settings.smallMode}")
                 +taskText()
             if k=='daily' || k=='todo'
               .item-button-left
                 button.button.button-large.button-clear.button-positive.icon(ng-click='changeCheck(task, $event)')
-                  i(ng-class=" ::{'icon ion-checkmark-circled': task.completed, 'checkbox-icon': !task.completed }")
+                  i(ng-class=" ::{'icon ion-checkmark-circled': task.completed, 'checkbox-icon': !task.completed, 'small-mode': settings.smallMode}")
                 +taskText()
 
                 if k=='todo'

--- a/views/app/settings.jade
+++ b/views/app/settings.jade
@@ -27,6 +27,9 @@ script(id="views/app.settings.html",type='text/ng-template')
         +premiumAndAds()
 
       .padding
+        ion-toggle(ng-model='settings.smallMode', ng-change='User.save()') Small Mode
+
+      .padding
         button.button.button-block(ng-click='User.user.ops.sleep({})')
             span(ng-show='user.preferences.sleep') Check Out of Inn
             span(ng-hide='user.preferences.sleep') Rest in the Inn


### PR DESCRIPTION
Requested this on the Trello a long time ago but was shot down due to accessibility concerns. So I went ahead and wrote the code to add a "Small Mode" option to settings -- all it does is reduce the enormous 100px list items to a more managable 80px, meaning that people with good eyesight, average size fingers, and a lot of things to do can fit another 25% of tasks onscreen.

Tested in browser and on iOS. Wasn't able to try it on Android due to some long-standing disagreements between my Java compiler and the LocalNotification plugin. If someone could confirm that it works there, that would be great.

Lemme know if there are any changes you'd like me to make before this can be merged! I'll be using it on my device in any case, but I'd love to see this feature make it into production.