### PR TITLE
Workaround for toast lag

### DIFF
--- a/_convert_these/app/scripts/services/notificationServices.js
+++ b/_convert_these/app/scripts/services/notificationServices.js
@@ -30,14 +30,14 @@ angular.module('notificationServices', []).
 
                 if (timer) {
                     clearTimeout(timer);
-                    timer = setTimeout(this.hide, 2000)
+                    timer = setTimeout(this.hide, 6000)
                 }
 
                 if (active == false) {
                     active = true;
 
                     $('#notification').transition({ y: notifyheight, x: 0 });
-                    timer = setTimeout(this.hide, 2000);
+                    timer = setTimeout(this.hide, 6000);
                 }
 
             },
@@ -81,7 +81,7 @@ angular.module('notificationServices', []).
             },
 
             init: function () {
-                timer = setTimeout(this.hide, 2000);
+                timer = setTimeout(this.hide, 6000);
             }
 
         }


### PR DESCRIPTION
See #362 for further details. This is a workaround to allow the user to
read these messages before they fade, as it's common to have lag equal
to or exceeding the current 2-second timer.